### PR TITLE
ci: add Docker-based build, test, lint, and security scan

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,7 @@ jobs:
           context: .
           file: Dockerfile
           push: false
+          load: true
           tags: |
             algo-bot-ci:${{ github.sha }}
           cache-from: type=gha
@@ -56,6 +57,7 @@ jobs:
           context: .
           file: Dockerfile
           push: false
+          load: true
           tags: |
             algo-bot-ci:${{ github.sha }}
           cache-from: type=gha

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,43 +1,71 @@
-name: ci
+name: CI
 
 on:
   push:
-    branches: [ main ]
+    branches: [ "main" ]
   pull_request:
-    branches: [ main ]
+    branches: [ "main" ]
 
-security-scan:
-    runs-on: ubuntu-latest
-    needs: build-test
-    steps:
-      - uses: actions/checkout@v4
-      - name: Build image
-        run: docker build -t algo-bot-ci:latest .
-      - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.20.0
-        with:
-          image-ref: 'algo-bot-ci:latest'
-          vuln-type: 'os,library'
-          severity: 'CRITICAL,HIGH'
-          ignore-unfixed: true
-          exit-code: '1'
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build-test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
 
-      # Build image
-      - name: Build Docker image
-        run: docker build -t algo-bot-ci:latest .
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
-      # Run tests inside the image
-      - name: Run tests
-        run: docker run --rm algo-bot-ci:latest poetry run pytest -q
+      - name: Build image (with cache)
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: Dockerfile
+          push: false
+          tags: |
+            algo-bot-ci:${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
-      # Lint & format checks inside the image
-      - name: Ruff & Black checks
-        run: |
-          docker run --rm algo-bot-ci:latest poetry run ruff check .
-          docker run --rm algo-bot-ci:latest poetry run black --check .
+      - name: Run tests (pytest)
+        run: docker run --rm --entrypoint pytest algo-bot-ci:${{ github.sha }} -q
+
+      - name: Ruff (lint)
+        run: docker run --rm --entrypoint ruff algo-bot-ci:${{ github.sha }} check .
+
+      - name: Black (format check)
+        run: docker run --rm --entrypoint black algo-bot-ci:${{ github.sha }} --check .
+
+  security-scan:
+    runs-on: ubuntu-latest
+    needs: build-test
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build image (reuse cache)
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: Dockerfile
+          push: false
+          tags: |
+            algo-bot-ci:${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Trivy scan (CRITICAL,HIGH)
+        uses: aquasecurity/trivy-action@0.20.0
+        with:
+          image-ref: 'algo-bot-ci:${{ github.sha }}'
+          vuln-type: 'os,library'
+          severity: 'CRITICAL,HIGH'
+          ignore-unfixed: true
+          exit-code: '1'

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![CI](https://github.com/YOUR_ORG/YOUR_REPO/actions/workflows/ci.yml/badge.svg)](https://github.com/YOUR_ORG/YOUR_REPO/actions/workflows/ci.yml)
+
 # algo-trading-vibe-built
 Currently provides no license - demo purposes only
 


### PR DESCRIPTION
- Added GitHub Actions workflow for CI on push and PR to main
- Builds Docker image using Buildx with cache
- Runs pytest inside container to validate unit tests
- Runs Ruff (lint) and Black (format check) inside container
- Added Trivy scan step to detect CRITICAL and HIGH vulnerabilities
- Enabled concurrency to cancel redundant runs