### PR TITLE
Add smoke test for CLI hello command

### DIFF
--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1,3 +1,12 @@
 # tests/test_smoke.py
+from click.testing import CliRunner
+
+from app import hello
+
+
 def test_smoke():
-    assert True
+    """Invoke the hello CLI command and ensure it runs successfully."""
+    runner = CliRunner()
+    result = runner.invoke(hello)
+    assert result.exit_code == 0
+    assert "Algo Bot MVP is alive." in result.output


### PR DESCRIPTION
## Summary
- add smoke test using `click.CliRunner` for `hello` CLI command
- verify `hello` exits successfully and outputs expected message

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a4a42001ac8332a13c0e61759cb96f