### PR TITLE
docs: document helper scripts

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
+# Install project dependencies and set up pre-commit hooks.
+# Usage: ./scripts/bootstrap.sh
 set -euo pipefail
 poetry install
 poetry run pre-commit install
 echo "Bootstrap complete. Copy .env.example to .env (never commit .env)."
+

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# Verify the development environment by rebuilding and running core checks.
+# Usage: ./scripts/doctor.sh
 set -euo pipefail
 
 echo "== Rebuilding image =="

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# Run application commands inside the app container.
+# Usage: ./scripts/run.sh <command> [args]
 set -euo pipefail
 set -x
 # Forward all CLI args to the container's entrypoint

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# Rebuild the Docker image from scratch and remove dangling layers.
+# Usage: ./scripts/update.sh
 set -euo pipefail
 # Rebuild the image and prune dangling layers
 docker compose build --no-cache

--- a/scripts/validate_day1.sh
+++ b/scripts/validate_day1.sh
@@ -1,5 +1,6 @@
-# scripts/validate_day1.sh
 #!/usr/bin/env bash
+# Validate required files and tooling for the Day 1 project setup.
+# Usage: ./scripts/validate_day1.sh
 set -euo pipefail
 
 RED=$'\e[31m'; GREEN=$'\e[32m'; YELLOW=$'\e[33m'; NC=$'\e[0m'


### PR DESCRIPTION
## Summary
- document helper shell scripts with purpose and usage
- normalize scripts to include trailing newline for POSIX compatibility

## Testing
- `make lint` *(fails: docker not found)*
- `make test` *(fails: docker not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a4a713f80c8332bcf6d8bff856ee8a