### PR TITLE
docs: add AGENTS guidelines for sprint-based development

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,18 @@
+# Agent Guidelines
+
+## Sprint-oriented development
+- Break work into small, demo-able increments.
+- Associate commits with task or sprint identifiers.
+
+## Containerization
+- Use the existing `dockerfile` and `docker-compose.yml` for development and demos.
+- Build and run containers with:
+  ```bash
+  docker build -f dockerfile -t algo-trading-vibe .
+  docker compose up
+  ```
+
+## Best practices
+- Reference `.pre-commit-config.yaml` for linting and formatting.
+- Run tests or demo scripts before each commit.
+- Propose improvements and note outstanding work for future sprints.


### PR DESCRIPTION
## Summary
- Establish repository-wide AGENTS guidelines for sprint-oriented work, container usage, and development best practices

## Testing
- `pytest`
- `pre-commit run --files AGENTS.md` *(fails: command not found, attempted installation but 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a4ab37a140833285969e534508bba6