### PR TITLE
docs: update sprint plans with status and roadmap

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,8 +22,13 @@
 - Follow PEP 8 naming and formatting guidelines.
 - Include module/function docstrings and descriptive comments.
 - Structure functions and classes around the single-responsibility principle.
+- Use '-' for bullet lists and avoid other unicode characters in documentation or code comments.
 
 ## Architecture Guidelines
 - Isolate domain logic from I/O and external systems to maintain clear layers.
 - Favor reusable modules and avoid tightly coupled code for maintainability.
 - Use dependency injection or interfaces to allow components to be interchangeable.
+
+## Contribution guardrails
+- Keep each pull request focused on a single atomic change.
+- Create a new pull request for any unrelated updates to coding agent instructions or behavior.

--- a/docs/progress-report.md
+++ b/docs/progress-report.md
@@ -1,0 +1,29 @@
+# Progress Report — Algo Trading Bot MVP
+
+## Current Status Snapshot
+- **Sprint 1** is in progress: foundational repo scaffolding and CI are complete, but trading features remain outstanding.【F:docs/sprint-plan/sprintplan.json†L4-L19】
+- **Sprints 2 and 3** have not started and depend on Sprint 1 delivering the core trading loop and risk controls.【F:docs/sprint-plan/sprintplan.json†L20-L52】
+
+## Completed Work
+- Repository skeleton, Docker/Poetry setup, and CI/CD automation are finished per the Sprint 1 plan.【F:docs/sprint-plan/sprint-1.json†L9-L28】
+- Command-line scaffolding (`hello` and `fetch-bars`) and Alpaca helper functions exist, providing the basis for market data retrieval and order submission stubs.【F:src/app.py†L1-L51】【F:src/data/providers/alpaca.py†L1-L125】
+
+## Remaining Gaps
+- Alpaca integration is only partially implemented: the fetch CLI entrypoint defined in the Sprint plan is missing and the order helper lacks an automated demo, so the epic remains in progress.【F:docs/sprint-plan/sprint-1.json†L31-L52】
+- Strategy, policy, execution loop, logging, and validation epics in Sprint 1 have not started; corresponding modules are absent from the current `src/` layout.【F:docs/sprint-plan/sprint-1.json†L55-L142】【288a7b†L1-L2】
+- The README advertises strategy, policy, backtester, and logging features that are not yet implemented, risking stakeholder confusion until documentation is updated post-delivery.【F:README.md†L5-L18】【F:docs/sprint-plan/sprint-1.json†L132-L138】
+
+## Plan & Next Steps
+1. **Finish Sprint 1 core loop**
+   - Implement SMA strategy module and integrate it into a scheduled trading loop.
+   - Build the policy engine with max-notional enforcement and wire structured logging around the execution path.
+   - Deliver a paper-trading demo run and reconcile README claims with actual capabilities.
+2. **Prepare for Sprint 2** (blocked until Sprint 1 closes)
+   - Start database schema/migration work and historical data loaders to unblock backtesting epics.【F:docs/sprint-plan/sprint-2.json†L9-L28】
+   - Define interfaces for policy extensions and PnL tracking to ensure continuity into Sprint 3.
+3. **Refine roadmap checkpoints**
+   - Revisit Sprint 2 and Sprint 3 entry criteria once Sprint 1 is feature-complete to avoid cascading delays.【F:docs/sprint-plan/sprintplan.json†L20-L52】
+
+## Risks & Mitigations
+- **Schedule risk**: With most Sprint 1 epics untouched, downstream sprints will slip. *Mitigation*: focus the next iteration on closing Sprint 1 acceptance criteria before starting parallel work.
+- **Documentation drift**: Public docs overstate functionality. *Mitigation*: schedule README/doc revisions as part of Sprint 1 review to align expectations.【F:docs/sprint-plan/sprint-1.json†L132-L138】

--- a/docs/progress-report.md
+++ b/docs/progress-report.md
@@ -1,29 +1,29 @@
-# Progress Report — Algo Trading Bot MVP
+# Progress Report - Algo Trading Bot MVP
 
 ## Current Status Snapshot
-- **Sprint 1** is in progress: foundational repo scaffolding and CI are complete, but trading features remain outstanding.【F:docs/sprint-plan/sprintplan.json†L4-L19】
-- **Sprints 2 and 3** have not started and depend on Sprint 1 delivering the core trading loop and risk controls.【F:docs/sprint-plan/sprintplan.json†L20-L52】
+- **Sprint 1** is in progress: foundational repository scaffolding and CI are complete, but trading features remain outstanding.
+- **Sprints 2 and 3** have not started and depend on Sprint 1 delivering the core trading loop and risk controls.
 
 ## Completed Work
-- Repository skeleton, Docker/Poetry setup, and CI/CD automation are finished per the Sprint 1 plan.【F:docs/sprint-plan/sprint-1.json†L9-L28】
-- Command-line scaffolding (`hello` and `fetch-bars`) and Alpaca helper functions exist, providing the basis for market data retrieval and order submission stubs.【F:src/app.py†L1-L51】【F:src/data/providers/alpaca.py†L1-L125】
+- Repository skeleton, Docker and Poetry setup, and CI/CD automation are finished per the Sprint 1 plan.
+- Command-line scaffolding (`hello` and `fetch-bars`) and Alpaca helper functions exist, providing the basis for market data retrieval and order submission stubs.
 
 ## Remaining Gaps
-- Alpaca integration is only partially implemented: the fetch CLI entrypoint defined in the Sprint plan is missing and the order helper lacks an automated demo, so the epic remains in progress.【F:docs/sprint-plan/sprint-1.json†L31-L52】
-- Strategy, policy, execution loop, logging, and validation epics in Sprint 1 have not started; corresponding modules are absent from the current `src/` layout.【F:docs/sprint-plan/sprint-1.json†L55-L142】【288a7b†L1-L2】
-- The README advertises strategy, policy, backtester, and logging features that are not yet implemented, risking stakeholder confusion until documentation is updated post-delivery.【F:README.md†L5-L18】【F:docs/sprint-plan/sprint-1.json†L132-L138】
+- Alpaca integration is only partially implemented: the fetch CLI entrypoint defined in the Sprint plan is missing and the order helper lacks an automated demo, so the epic remains in progress.
+- Strategy, policy, execution loop, logging, and validation epics in Sprint 1 have not started; corresponding modules are absent from the current `src/` layout.
+- The README advertises strategy, policy, backtester, and logging features that are not yet implemented, risking stakeholder confusion until documentation is updated post-delivery.
 
-## Plan & Next Steps
+## Plan and Next Steps
 1. **Finish Sprint 1 core loop**
    - Implement SMA strategy module and integrate it into a scheduled trading loop.
-   - Build the policy engine with max-notional enforcement and wire structured logging around the execution path.
+   - Build the policy engine with max-notional enforcement and add structured logging around the execution path.
    - Deliver a paper-trading demo run and reconcile README claims with actual capabilities.
 2. **Prepare for Sprint 2** (blocked until Sprint 1 closes)
-   - Start database schema/migration work and historical data loaders to unblock backtesting epics.【F:docs/sprint-plan/sprint-2.json†L9-L28】
+   - Start database schema and migration work along with historical data loaders to unblock backtesting epics.
    - Define interfaces for policy extensions and PnL tracking to ensure continuity into Sprint 3.
 3. **Refine roadmap checkpoints**
-   - Revisit Sprint 2 and Sprint 3 entry criteria once Sprint 1 is feature-complete to avoid cascading delays.【F:docs/sprint-plan/sprintplan.json†L20-L52】
+   - Revisit Sprint 2 and Sprint 3 entry criteria once Sprint 1 is feature-complete to avoid cascading delays.
 
-## Risks & Mitigations
+## Risks and Mitigations
 - **Schedule risk**: With most Sprint 1 epics untouched, downstream sprints will slip. *Mitigation*: focus the next iteration on closing Sprint 1 acceptance criteria before starting parallel work.
-- **Documentation drift**: Public docs overstate functionality. *Mitigation*: schedule README/doc revisions as part of Sprint 1 review to align expectations.【F:docs/sprint-plan/sprint-1.json†L132-L138】
+- **Documentation drift**: Public docs overstate functionality. *Mitigation*: schedule README and doc revisions as part of the Sprint 1 review to align expectations.

--- a/docs/sprint-plan/sprint-1.json
+++ b/docs/sprint-plan/sprint-1.json
@@ -1,6 +1,6 @@
 {
   "sprint": {
-    "name": "Sprint 1 — Foundation & First Paper Trade",
+    "name": "Sprint 1 \u2014 Foundation & First Paper Trade",
     "duration_weeks": 3,
     "milestone": "v0.1.0-alpha",
     "goal": "Deliver a working bot skeleton that can fetch market data, run SMA strategy, enforce basic policy, and place paper trades.",
@@ -24,7 +24,8 @@
             "definition_of_done": "Pull requests automatically trigger lint & unit tests successfully.",
             "status": "complete"
           }
-        ]
+        ],
+        "status": "complete"
       },
       {
         "name": "Alpaca Integration (Paper Trading)",
@@ -35,16 +36,20 @@
             "description": "Implement data provider module with function to fetch OHLCV bars for a symbol.",
             "schedule_day": 3,
             "definition_of_done": "`python -m src.data.providers.alpaca fetch AAPL` prints OHLCV bars to console.",
-            "status": "complete"
+            "status": "not-started",
+            "notes": "fetch entrypoint is missing; provider module currently only exposes helpers used by CLI."
           },
           {
             "id": "S1-E2-I2",
             "title": "Connect to Alpaca Paper Trading API",
             "description": "Implement order client to place a market order with sandbox account.",
             "schedule_day": 4,
-            "definition_of_done": "Test script places a $1 notional trade in Alpaca paper account and logs order id."
+            "definition_of_done": "Test script places a $1 notional trade in Alpaca paper account and logs order id.",
+            "status": "in-progress",
+            "notes": "submit_order helper exists but lacks test/demo script to satisfy definition of done."
           }
-        ]
+        ],
+        "status": "in-progress"
       },
       {
         "name": "Strategy Engine (Basic SMA)",
@@ -54,16 +59,19 @@
             "title": "Implement SMA crossover function",
             "description": "Create function to compute SMA fast/slow and return buy/sell/none signals.",
             "schedule_day": 5,
-            "definition_of_done": "Unit test shows correct buy/sell/none signal on sample CSV data."
+            "definition_of_done": "Unit test shows correct buy/sell/none signal on sample CSV data.",
+            "status": "not-started"
           },
           {
             "id": "S1-E3-I2",
             "title": "Integrate SMA into bot loop",
             "description": "Wire strategy into app scheduler; on each tick, compute signal using Alpaca data.",
             "schedule_day": 6,
-            "definition_of_done": "When running bot, SMA signals (buy/sell/none) are printed to logs."
+            "definition_of_done": "When running bot, SMA signals (buy/sell/none) are printed to logs.",
+            "status": "not-started"
           }
-        ]
+        ],
+        "status": "not-started"
       },
       {
         "name": "Policy Engine (Stub)",
@@ -73,35 +81,41 @@
             "title": "Create policy engine module",
             "description": "Implement placeholder policy checks (always returns ok).",
             "schedule_day": 7,
-            "definition_of_done": "All trade signals pass through policy engine; log shows 'policy=ok'."
+            "definition_of_done": "All trade signals pass through policy engine; log shows 'policy=ok'.",
+            "status": "not-started"
           },
           {
             "id": "S1-E4-I2",
             "title": "Add max notional check",
             "description": "Implement limit: max notional $1000 per trade.",
             "schedule_day": 8,
-            "definition_of_done": "Signal exceeding notional is blocked and logged in audit."
+            "definition_of_done": "Signal exceeding notional is blocked and logged in audit.",
+            "status": "not-started"
           }
-        ]
+        ],
+        "status": "not-started"
       },
       {
         "name": "Execution & Audit Logging",
         "issues": [
           {
             "id": "S1-E5-I1",
-            "title": "Wire signal → policy → order",
-            "description": "Complete loop: strategy → policy → Alpaca order → log result.",
+            "title": "Wire signal \u2192 policy \u2192 order",
+            "description": "Complete loop: strategy \u2192 policy \u2192 Alpaca order \u2192 log result.",
             "schedule_day": 9,
-            "definition_of_done": "Running bot places valid trade in Alpaca paper account, logs full decision trace."
+            "definition_of_done": "Running bot places valid trade in Alpaca paper account, logs full decision trace.",
+            "status": "not-started"
           },
           {
             "id": "S1-E5-I2",
             "title": "Structured audit logging",
             "description": "Log every decision in JSON format (strategy, policy decision, order result).",
             "schedule_day": 10,
-            "definition_of_done": "Audit log file contains JSON entries per tick with timestamp."
+            "definition_of_done": "Audit log file contains JSON entries per tick with timestamp.",
+            "status": "not-started"
           }
-        ]
+        ],
+        "status": "not-started"
       },
       {
         "name": "Validation & Demo",
@@ -111,16 +125,20 @@
             "title": "Run 1-day paper demo",
             "description": "Deploy bot with Docker Compose, run for 1 day using Alpaca sandbox.",
             "schedule_day": 12,
-            "definition_of_done": "Audit logs show trades executed with SMA strategy; policy enforced."
+            "definition_of_done": "Audit logs show trades executed with SMA strategy; policy enforced.",
+            "status": "not-started"
           },
           {
             "id": "S1-E6-I2",
             "title": "Sprint 1 Review & Documentation",
             "description": "Write README with setup/run instructions, update docs with Sprint 1 outcomes.",
             "schedule_day": 13,
-            "definition_of_done": "Docs explain how to build, run, validate Sprint 1 bot."
+            "definition_of_done": "Docs explain how to build, run, validate Sprint 1 bot.",
+            "status": "not-started",
+            "notes": "README claims completed features that are not yet implemented; needs update post-sprint."
           }
-        ]
+        ],
+        "status": "not-started"
       }
     ]
   }

--- a/docs/sprint-plan/sprint-1.json
+++ b/docs/sprint-plan/sprint-1.json
@@ -1,6 +1,6 @@
 {
   "sprint": {
-    "name": "Sprint 1 \u2014 Foundation & First Paper Trade",
+    "name": "Sprint 1 - Foundation & First Paper Trade",
     "duration_weeks": 3,
     "milestone": "v0.1.0-alpha",
     "goal": "Deliver a working bot skeleton that can fetch market data, run SMA strategy, enforce basic policy, and place paper trades.",

--- a/docs/sprint-plan/sprint-2.json
+++ b/docs/sprint-plan/sprint-2.json
@@ -1,6 +1,6 @@
 {
   "sprint": {
-    "name": "Sprint 2 \u2014 Backtesting & Risk Enhancements",
+    "name": "Sprint 2 - Backtesting & Risk Enhancements",
     "duration_weeks": 3,
     "milestone": "v0.2.0-beta",
     "goal": "Introduce a reproducible backtesting workflow, extend the Policy Engine (position limits, daily loss cap), and add basic PnL/positions tracking with CLI reporting.",

--- a/docs/sprint-plan/sprint-2.json
+++ b/docs/sprint-plan/sprint-2.json
@@ -1,6 +1,6 @@
 {
   "sprint": {
-    "name": "Sprint 2 — Backtesting & Risk Enhancements",
+    "name": "Sprint 2 \u2014 Backtesting & Risk Enhancements",
     "duration_weeks": 3,
     "milestone": "v0.2.0-beta",
     "goal": "Introduce a reproducible backtesting workflow, extend the Policy Engine (position limits, daily loss cap), and add basic PnL/positions tracking with CLI reporting.",
@@ -13,16 +13,19 @@
             "title": "SQLite schema & migration script",
             "description": "Create SQLite tables for ohlcv, positions, orders, executions, pnl_snapshots, audit_log. Provide migration script.",
             "schedule_day": 1,
-            "definition_of_done": "Running migration creates all tables; PR includes schema SQL and docs snippet."
+            "definition_of_done": "Running migration creates all tables; PR includes schema SQL and docs snippet.",
+            "status": "not-started"
           },
           {
             "id": "S2-E1-I2",
-            "title": "Data loader for OHLCV (CSV → SQLite)",
+            "title": "Data loader for OHLCV (CSV \u2192 SQLite)",
             "description": "CLI to ingest historical CSV bars into SQLite (symbol, ts, open, high, low, close, volume).",
             "schedule_day": 2,
-            "definition_of_done": "`python -m src.data.storage load --csv data/AAPL.csv --symbol AAPL` populates rows; counts printed."
+            "definition_of_done": "`python -m src.data.storage load --csv data/AAPL.csv --symbol AAPL` populates rows; counts printed.",
+            "status": "not-started"
           }
-        ]
+        ],
+        "status": "not-started"
       },
       {
         "name": "Backtesting Engine (Core)",
@@ -32,42 +35,49 @@
             "title": "Backtest loop & signal evaluation",
             "description": "Implement vectorized/iterative loop: read bars from SQLite, run SMA strategy, produce signal stream.",
             "schedule_day": 3,
-            "definition_of_done": "Backtest returns signal count and sample preview for given date range."
+            "definition_of_done": "Backtest returns signal count and sample preview for given date range.",
+            "status": "not-started"
           },
           {
             "id": "S2-E2-I2",
             "title": "Order simulation & fills",
             "description": "Simulate market orders at next bar open; record executions and update positions.",
             "schedule_day": 4,
-            "definition_of_done": "Executions persisted; positions updated; unit tests cover buy→sell round trip."
+            "definition_of_done": "Executions persisted; positions updated; unit tests cover buy\u2192sell round trip.",
+            "status": "not-started"
           },
           {
             "id": "S2-E2-I3",
             "title": "Backtest metrics (PnL, max DD, win rate)",
             "description": "Compute basic metrics and equity curve; return JSON report + CSV equity curve.",
             "schedule_day": 5,
-            "definition_of_done": "Backtest outputs JSON with pnl/max_drawdown/win_rate and writes equity_curve.csv."
+            "definition_of_done": "Backtest outputs JSON with pnl/max_drawdown/win_rate and writes equity_curve.csv.",
+            "status": "not-started"
           }
-        ]
+        ],
+        "status": "not-started"
       },
       {
-        "name": "Policy Engine — Extended Limits",
+        "name": "Policy Engine \u2014 Extended Limits",
         "issues": [
           {
             "id": "S2-E3-I1",
             "title": "Position limit per symbol",
             "description": "Block orders that would exceed per-symbol notional cap.",
             "schedule_day": 6,
-            "definition_of_done": "Unit test: order exceeding cap returns status=blocked with violation=per_symbol_limit."
+            "definition_of_done": "Unit test: order exceeding cap returns status=blocked with violation=per_symbol_limit.",
+            "status": "not-started"
           },
           {
             "id": "S2-E3-I2",
             "title": "Daily loss (drawdown) cap",
             "description": "Block new orders when daily PnL < -daily_max_drawdown.",
             "schedule_day": 7,
-            "definition_of_done": "Unit test simulating negative day PnL yields blocked decision with violation=daily_drawdown."
+            "definition_of_done": "Unit test simulating negative day PnL yields blocked decision with violation=daily_drawdown.",
+            "status": "not-started"
           }
-        ]
+        ],
+        "status": "not-started"
       },
       {
         "name": "PnL & Positions Tracking",
@@ -77,16 +87,19 @@
             "title": "Positions model & updater",
             "description": "Single source of truth for current position qty and average cost per symbol.",
             "schedule_day": 8,
-            "definition_of_done": "After simulated fills, positions reflect correct qty/avg_cost in SQLite."
+            "definition_of_done": "After simulated fills, positions reflect correct qty/avg_cost in SQLite.",
+            "status": "not-started"
           },
           {
             "id": "S2-E4-I2",
             "title": "Daily PnL snapshot",
             "description": "Write end-of-day (or end-of-run) PnL rows to pnl_snapshots table.",
             "schedule_day": 9,
-            "definition_of_done": "Snapshot rows created with realized/unrealized PnL; unit test verifies totals."
+            "definition_of_done": "Snapshot rows created with realized/unrealized PnL; unit test verifies totals.",
+            "status": "not-started"
           }
-        ]
+        ],
+        "status": "not-started"
       },
       {
         "name": "CLI & Reporting",
@@ -96,16 +109,19 @@
             "title": "Backtest CLI command",
             "description": "Add CLI: `backtest --symbols AAPL --start 2023-01-01 --end 2023-12-31 --strat sma`",
             "schedule_day": 10,
-            "definition_of_done": "Command runs end-to-end; prints metrics JSON path and equity curve path."
+            "definition_of_done": "Command runs end-to-end; prints metrics JSON path and equity curve path.",
+            "status": "not-started"
           },
           {
             "id": "S2-E5-I2",
             "title": "Report artifact & README snippet",
             "description": "Save metrics JSON and equity curve CSV under artifacts/backtests/<timestamp>/; document usage in README.",
             "schedule_day": 11,
-            "definition_of_done": "Artifacts folder contains JSON + CSV files; README shows example run and outputs."
+            "definition_of_done": "Artifacts folder contains JSON + CSV files; README shows example run and outputs.",
+            "status": "not-started"
           }
-        ]
+        ],
+        "status": "not-started"
       },
       {
         "name": "Validation & Docs",
@@ -115,16 +131,19 @@
             "title": "Benchmark vs SPY (sanity run)",
             "description": "Run backtest on AAPL and SPY for 12 months; compare strategy returns to SPY buy/hold baseline.",
             "schedule_day": 12,
-            "definition_of_done": "Benchmark table included in artifacts; README updated with results summary."
+            "definition_of_done": "Benchmark table included in artifacts; README updated with results summary.",
+            "status": "not-started"
           },
           {
             "id": "S2-E6-I2",
             "title": "Sprint 2 Review & Documentation",
             "description": "Summarize changes, update architecture.md (backtest path), and add RUNBOOK backtesting section.",
             "schedule_day": 13,
-            "definition_of_done": "Docs updated; reviewers can reproduce the backtest and locate artifacts."
+            "definition_of_done": "Docs updated; reviewers can reproduce the backtest and locate artifacts.",
+            "status": "not-started"
           }
-        ]
+        ],
+        "status": "not-started"
       }
     ]
   }

--- a/docs/sprint-plan/sprint-3.json
+++ b/docs/sprint-plan/sprint-3.json
@@ -1,8 +1,6 @@
-
-
 {
   "sprint": {
-    "name": "Sprint 3 — Observability & Configurable Strategies",
+    "name": "Sprint 3 \u2014 Observability & Configurable Strategies",
     "duration_weeks": 3,
     "milestone": "v1.0.0-MVP",
     "goal": "Deliver MVP with multiple strategy options, policy configuration, observability (logs, CLI dashboard), and deploy automation.",
@@ -15,16 +13,19 @@
             "title": "Config-driven strategy selection",
             "description": "Support multiple strategies (SMA, EMA, buy-and-hold stub) selectable via config.yml.",
             "schedule_day": 1,
-            "definition_of_done": "Config.yml contains 'strategy: sma/ema/buyhold'; CLI run respects strategy choice."
+            "definition_of_done": "Config.yml contains 'strategy: sma/ema/buyhold'; CLI run respects strategy choice.",
+            "status": "not-started"
           },
           {
             "id": "S3-E1-I2",
             "title": "Strategy interface refactor",
             "description": "Refactor strategy into pluggable interface class with eval_signals method.",
             "schedule_day": 2,
-            "definition_of_done": "All strategies implement IStrategy interface; backtest and live run accept any strategy."
+            "definition_of_done": "All strategies implement IStrategy interface; backtest and live run accept any strategy.",
+            "status": "not-started"
           }
-        ]
+        ],
+        "status": "not-started"
       },
       {
         "name": "Policy Configuration",
@@ -34,16 +35,19 @@
             "title": "Configurable policy thresholds",
             "description": "Move per-symbol and daily risk limits into config.yml with validation.",
             "schedule_day": 3,
-            "definition_of_done": "Editing config.yml updates runtime policy enforcement; validation errors printed on load."
+            "definition_of_done": "Editing config.yml updates runtime policy enforcement; validation errors printed on load.",
+            "status": "not-started"
           },
           {
             "id": "S3-E2-I2",
             "title": "Config schema & documentation",
             "description": "Document config.yml fields and provide example config files.",
             "schedule_day": 4,
-            "definition_of_done": "README contains annotated config.yml example; config schema defined in code."
+            "definition_of_done": "README contains annotated config.yml example; config schema defined in code.",
+            "status": "not-started"
           }
-        ]
+        ],
+        "status": "not-started"
       },
       {
         "name": "Observability & Dashboard",
@@ -53,23 +57,27 @@
             "title": "Health checks",
             "description": "Add periodic checks for API connectivity and config load errors; log status.",
             "schedule_day": 5,
-            "definition_of_done": "Health check runs every N minutes; failures log to structured log with error_code."
+            "definition_of_done": "Health check runs every N minutes; failures log to structured log with error_code.",
+            "status": "not-started"
           },
           {
             "id": "S3-E3-I2",
             "title": "CLI dashboard for trades & PnL",
             "description": "Implement CLI 'report' command: shows trade history, open positions, and cumulative PnL.",
             "schedule_day": 6,
-            "definition_of_done": "`python -m cli report` outputs readable summary table from SQLite data."
+            "definition_of_done": "`python -m cli report` outputs readable summary table from SQLite data.",
+            "status": "not-started"
           },
           {
             "id": "S3-E3-I3",
             "title": "Optional lightweight web dashboard",
             "description": "If time allows, add FastAPI/Flask web UI to view trades and metrics in browser.",
             "schedule_day": 7,
-            "definition_of_done": "Start server with `python -m web.dashboard`; browser shows trades table and metrics JSON."
+            "definition_of_done": "Start server with `python -m web.dashboard`; browser shows trades table and metrics JSON.",
+            "status": "not-started"
           }
-        ]
+        ],
+        "status": "not-started"
       },
       {
         "name": "Deployment & Ops",
@@ -79,16 +87,19 @@
             "title": "Deployment script",
             "description": "Write update.sh script to rebuild Docker image, restart container, and run migrations.",
             "schedule_day": 8,
-            "definition_of_done": "`./scripts/update.sh` rebuilds image, runs migrations, restarts bot container."
+            "definition_of_done": "`./scripts/update.sh` rebuilds image, runs migrations, restarts bot container.",
+            "status": "not-started"
           },
           {
             "id": "S3-E4-I2",
             "title": "Version tagging",
             "description": "Tag Docker images and releases with version numbers (semver) and push to registry.",
             "schedule_day": 9,
-            "definition_of_done": "Running CI pipeline produces docker image 'algo-bot:v1.0.0' pushed to registry."
+            "definition_of_done": "Running CI pipeline produces docker image 'algo-bot:v1.0.0' pushed to registry.",
+            "status": "not-started"
           }
-        ]
+        ],
+        "status": "not-started"
       },
       {
         "name": "Documentation & Validation",
@@ -98,16 +109,19 @@
             "title": "Docs update & final runbook",
             "description": "Finalize documentation: architecture updates, strategy usage, config setup, deployment runbook.",
             "schedule_day": 10,
-            "definition_of_done": "Docs folder contains runbook.md and updated architecture.md; README has usage examples."
+            "definition_of_done": "Docs folder contains runbook.md and updated architecture.md; README has usage examples.",
+            "status": "not-started"
           },
           {
             "id": "S3-E5-I2",
             "title": "MVP validation run",
             "description": "Run 1-week paper trading with multiple strategies; compare live vs. backtest performance.",
             "schedule_day": 11,
-            "definition_of_done": "Artifacts include metrics, logs, and summary report; consistency validated in review."
+            "definition_of_done": "Artifacts include metrics, logs, and summary report; consistency validated in review.",
+            "status": "not-started"
           }
-        ]
+        ],
+        "status": "not-started"
       }
     ]
   }

--- a/docs/sprint-plan/sprint-3.json
+++ b/docs/sprint-plan/sprint-3.json
@@ -1,6 +1,6 @@
 {
   "sprint": {
-    "name": "Sprint 3 \u2014 Observability & Configurable Strategies",
+    "name": "Sprint 3 - Observability & Configurable Strategies",
     "duration_weeks": 3,
     "milestone": "v1.0.0-MVP",
     "goal": "Deliver MVP with multiple strategy options, policy configuration, observability (logs, CLI dashboard), and deploy automation.",

--- a/docs/sprint-plan/sprintplan.json
+++ b/docs/sprint-plan/sprintplan.json
@@ -1,7 +1,7 @@
 {
   "sprints": [
     {
-      "name": "Sprint 1 \u2014 Foundation & First Paper Trade",
+      "name": "Sprint 1 - Foundation & First Paper Trade",
       "duration_weeks": 3,
       "milestone": "v0.1.0-alpha",
       "goal": "Deliver a working bot skeleton that can fetch market data, run SMA strategy, enforce basic policy, and place paper trades.",
@@ -18,7 +18,7 @@
       "progress": "Dev environment ready and Alpaca helpers stubbed; strategy/policy/logging work outstanding."
     },
     {
-      "name": "Sprint 2 \u2014 Backtesting & Risk Enhancements",
+      "name": "Sprint 2 - Backtesting & Risk Enhancements",
       "duration_weeks": 3,
       "milestone": "v0.2.0-beta",
       "goal": "Introduce backtesting framework and expand risk controls.",
@@ -34,7 +34,7 @@
       "progress": "Blocked on Sprint 1 delivering core trading loop."
     },
     {
-      "name": "Sprint 3 \u2014 Observability & Configurable Strategies",
+      "name": "Sprint 3 - Observability & Configurable Strategies",
       "duration_weeks": 3,
       "milestone": "v1.0.0-MVP",
       "goal": "Deliver full MVP with observability, configurable policies, and deployment automation.",

--- a/docs/sprint-plan/sprintplan.json
+++ b/docs/sprint-plan/sprintplan.json
@@ -1,7 +1,7 @@
 {
   "sprints": [
     {
-      "name": "Sprint 1 — Foundation & First Paper Trade",
+      "name": "Sprint 1 \u2014 Foundation & First Paper Trade",
       "duration_weeks": 3,
       "milestone": "v0.1.0-alpha",
       "goal": "Deliver a working bot skeleton that can fetch market data, run SMA strategy, enforce basic policy, and place paper trades.",
@@ -13,10 +13,12 @@
         "Policy engine (max notional check)",
         "Structured audit logging"
       ],
-      "validation": "Bot runs on Alpaca sandbox for 1 day; logs show SMA signals, policy check, and executed trades."
+      "validation": "Bot runs on Alpaca sandbox for 1 day; logs show SMA signals, policy check, and executed trades.",
+      "status": "in-progress",
+      "progress": "Dev environment ready and Alpaca helpers stubbed; strategy/policy/logging work outstanding."
     },
     {
-      "name": "Sprint 2 — Backtesting & Risk Enhancements",
+      "name": "Sprint 2 \u2014 Backtesting & Risk Enhancements",
       "duration_weeks": 3,
       "milestone": "v0.2.0-beta",
       "goal": "Introduce backtesting framework and expand risk controls.",
@@ -27,10 +29,12 @@
         "PnL tracking (daily, cumulative)",
         "Audit log integrated into backtest results"
       ],
-      "validation": "Run SMA strategy on historical AAPL/TSLA data; verify signals, orders, PnL and logs are consistent."
+      "validation": "Run SMA strategy on historical AAPL/TSLA data; verify signals, orders, PnL and logs are consistent.",
+      "status": "not-started",
+      "progress": "Blocked on Sprint 1 delivering core trading loop."
     },
     {
-      "name": "Sprint 3 — Observability & Configurable Strategies",
+      "name": "Sprint 3 \u2014 Observability & Configurable Strategies",
       "duration_weeks": 3,
       "milestone": "v1.0.0-MVP",
       "goal": "Deliver full MVP with observability, configurable policies, and deployment automation.",
@@ -42,7 +46,9 @@
         "Deployment script for upgrades",
         "Complete documentation (setup, run, extend)"
       ],
-      "validation": "Deploy bot for 1-week Alpaca sandbox run; backtest vs. live results compared; dashboard/report generated."
+      "validation": "Deploy bot for 1-week Alpaca sandbox run; backtest vs. live results compared; dashboard/report generated.",
+      "status": "not-started",
+      "progress": "Depends on earlier sprints for policy/backtest foundations."
     }
   ],
   "releases": [


### PR DESCRIPTION
## Summary
- annotate sprint 1 issues with current status and notes on incomplete Alpaca integration
- mark sprints 2 and 3 as not started and add progress context to the master sprint plan
- add a progress report summarizing completed work, remaining gaps, and upcoming priorities

## Testing
- poetry run pytest *(fails: ModuleNotFoundError: No module named 'src')*

------
https://chatgpt.com/codex/tasks/task_e_68eab505744883329c1dc360598132df