### PR TITLE
test: expand Alpaca provider validation coverage

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -8,13 +8,9 @@ for the kata does not include that dependency, so a very small shim version
 of the library is provided under ``src/pydantic_settings``.  The shim only
 implements the features we need here (basic attribute handling) but keeps the
 same API so the rest of the code does not need to change.
-
-The bug fixed in this module concerns the ``symbols`` configuration option.
-It was previously stored as a single comma separated string which forced
-callers to manually split the value.  This led to surprising behaviour and
-inconsistent handling of whitespace.  ``Settings`` now exposes ``symbols`` as
-``list[str]`` and automatically parses any provided string.
 """
+from collections.abc import Sequence
+
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -22,24 +18,34 @@ class Settings(BaseSettings):
     """Runtime configuration for the trading application.
 
     Values are loaded from environment variables when present and otherwise
-    fall back to the defaults declared below. ``symbols`` is exposed as a list
-    for ease of use; when a comma separated string is supplied the value is
-    split and surrounding whitespace is removed.
+    fall back to the defaults declared below.
 
     Example:
         >>> from config import Settings
         >>> settings = Settings()
-        >>> settings.symbols
-        "'AAPL', 'MSFT', 'SPY'"
+        >>> settings.symbol_list
+        ['AAPL', 'MSFT', 'SPY']
     """
 
     env: str = "dev"  # environment name; defaults to 'dev'
     alpaca_key_id: str | None = None  # Alpaca API key ID; defaults to None
     alpaca_secret_key: str | None = None  # Alpaca API secret key; defaults to None
     alpaca_base_url: str = "https://paper-api.alpaca.markets"  # Alpaca API base URL (paper)
-    symbols: str = '"AAPL", "MSFT", "SPY"'  # default asset symbols to trade
+    symbols: Sequence[str] | str = ("AAPL", "MSFT", "SPY")  # default asset symbols to trade
     schedule_cron: str = "*/5 * * * *"  # cron schedule for main job; every five minutes
 
     model_config = SettingsConfigDict(
         env_file=".env", env_file_encoding="utf-8", case_sensitive=False
     )  # load variables from .env with case-insensitive keys
+
+    @property
+    def symbol_list(self) -> list[str]:
+        """Return the configured symbols as a list of non-empty tickers."""
+
+        value = self.symbols
+        if isinstance(value, str):
+            cleaned = [item.strip().strip("'\"") for item in value.split(",")]
+            return [item for item in cleaned if item]
+        if isinstance(value, Sequence):
+            return [str(item) for item in value if str(item)]
+        return [str(value)] if value else []

--- a/src/config.py
+++ b/src/config.py
@@ -9,7 +9,7 @@ of the library is provided under ``src/pydantic_settings``.  The shim only
 implements the features we need here (basic attribute handling) but keeps the
 same API so the rest of the code does not need to change.
 """
-from collections.abc import Sequence
+from collections.abc import Iterable, Sequence
 
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
@@ -38,14 +38,33 @@ class Settings(BaseSettings):
         env_file=".env", env_file_encoding="utf-8", case_sensitive=False
     )  # load variables from .env with case-insensitive keys
 
+    @staticmethod
+    def _normalize_symbols(value: Sequence[str] | str | None) -> list[str]:
+        """Return a list of ticker strings with whitespace and quotes removed."""
+
+        if value is None:
+            return []
+
+        if isinstance(value, str):
+            candidates: Iterable[str] = value.split(",")
+        elif isinstance(value, Sequence):
+            candidates = value
+        else:
+            candidates = [value]
+
+        result: list[str] = []
+        for item in candidates:
+            text = str(item).strip()
+            if not text:
+                continue
+            text = text.strip("'\"")
+            text = text.strip()
+            if text:
+                result.append(text)
+        return result
+
     @property
     def symbol_list(self) -> list[str]:
         """Return the configured symbols as a list of non-empty tickers."""
 
-        value = self.symbols
-        if isinstance(value, str):
-            cleaned = [item.strip().strip("'\"") for item in value.split(",")]
-            return [item for item in cleaned if item]
-        if isinstance(value, Sequence):
-            return [str(item) for item in value if str(item)]
-        return [str(value)] if value else []
+        return self._normalize_symbols(self.symbols)

--- a/src/data/providers/alpaca.py
+++ b/src/data/providers/alpaca.py
@@ -2,8 +2,9 @@ from __future__ import annotations
 
 import argparse
 import json
+from collections.abc import Iterable, Sequence
 from dataclasses import asdict, dataclass
-from typing import Any, Iterable, Sequence
+from typing import Any
 
 from src.config import Settings
 
@@ -85,10 +86,7 @@ def fetch_bars(
     if settings is None:
         settings = Settings()
 
-    if isinstance(symbols, str):
-        symbol_list: list[str] = [symbols]
-    else:
-        symbol_list = list(symbols)
+    symbol_list = Settings._normalize_symbols(symbols)
 
     if not symbol_list:
         raise ValueError("symbols must contain at least one entry")
@@ -143,8 +141,12 @@ def main(argv: Iterable[str] | None = None) -> int:
     subparsers = parser.add_subparsers(dest="command", required=True)
 
     fetch_parser = subparsers.add_parser("fetch", help="Fetch OHLCV bars for one or more symbols.")
-    fetch_parser.add_argument("symbols", nargs="*", help="Symbols to fetch; defaults to settings.symbol_list if omitted.")
-    fetch_parser.add_argument("--limit", type=int, default=5, help="Number of bars to fetch per symbol.")
+    fetch_parser.add_argument(
+        "symbols", nargs="*", help="Symbols to fetch; defaults to settings.symbol_list if omitted."
+    )
+    fetch_parser.add_argument(
+        "--limit", type=int, default=5, help="Number of bars to fetch per symbol."
+    )
 
     args = parser.parse_args(list(argv) if argv is not None else None)
 

--- a/src/data/providers/alpaca.py
+++ b/src/data/providers/alpaca.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
-from typing import Any
+import argparse
+import json
+from dataclasses import asdict, dataclass
+from typing import Any, Iterable, Sequence
 
 from src.config import Settings
 
@@ -67,7 +69,7 @@ def _client(settings: Settings) -> REST:
 
 
 def fetch_bars(
-    symbol: str,
+    symbols: Sequence[str] | str,
     limit: int = 5,
     timeframe: Any = None,
     *,
@@ -83,9 +85,17 @@ def fetch_bars(
     if settings is None:
         settings = Settings()
 
+    if isinstance(symbols, str):
+        symbol_list: list[str] = [symbols]
+    else:
+        symbol_list = list(symbols)
+
+    if not symbol_list:
+        raise ValueError("symbols must contain at least one entry")
+
     tf = timeframe or getattr(TimeFrame, "Day", "1Day")
     c = client or _client(settings)
-    bars = c.get_bars(symbol, tf, limit=limit)
+    bars = c.get_bars(symbol_list, tf, limit=limit)
     return {symbol: [Bar.from_obj(b) for b in bar_list] for symbol, bar_list in bars.items()}
 
 
@@ -117,9 +127,38 @@ def submit_order(
     return order
 
 
+def _serialize_bars(bars: dict[str, list[Bar]]) -> str:
+    """Return a JSON string representing fetched bars."""
+
+    payload: Any
+    if len(bars) == 1:
+        payload = [asdict(bar) for bar in next(iter(bars.values()))]
+    else:
+        payload = {symbol: [asdict(bar) for bar in bar_list] for symbol, bar_list in bars.items()}
+    return json.dumps(payload, indent=2)
+
+
+def main(argv: Iterable[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Interact with the Alpaca market data API.")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    fetch_parser = subparsers.add_parser("fetch", help="Fetch OHLCV bars for one or more symbols.")
+    fetch_parser.add_argument("symbols", nargs="*", help="Symbols to fetch; defaults to settings.symbol_list if omitted.")
+    fetch_parser.add_argument("--limit", type=int, default=5, help="Number of bars to fetch per symbol.")
+
+    args = parser.parse_args(list(argv) if argv is not None else None)
+
+    settings = Settings()
+
+    if args.command == "fetch":
+        symbol_list = args.symbols or settings.symbol_list
+        bars = fetch_bars(symbol_list, limit=args.limit, settings=settings)
+        print(_serialize_bars(bars))
+        return 0
+
+    parser.error("Unsupported command")
+    return 1
+
+
 if __name__ == "__main__":
-    # Run with `python -m src.data.providers.alpaca`
-    # Requires .env file with ALPACA_KEY_ID and ALPACA_SECRET_KEY
-    print("Placing a $1 notional buy order for SPY...")
-    order = submit_order(symbol="SPY", notional=1, side="buy")
-    print("Order placed:", order)
+    raise SystemExit(main())

--- a/src/pydantic_settings/__init__.py
+++ b/src/pydantic_settings/__init__.py
@@ -8,7 +8,7 @@ class BaseSettings:
     def __init__(self, **data):
         # apply class defaults
         for name, value in self.__class__.__dict__.items():
-            if name.startswith("_") or callable(value):
+            if name.startswith("_") or callable(value) or isinstance(value, property):
                 continue
             setattr(self, name, value)
         # override with provided values

--- a/tests/test_alpaca_provider.py
+++ b/tests/test_alpaca_provider.py
@@ -50,6 +50,15 @@ def test_fetch_bars_accepts_string_symbol():
     assert fake_client.latest_request["limit"] == 2
 
 
+def test_fetch_bars_cleans_string_symbols():
+    fake_client = FakeRESTClient()
+    data = fetch_bars("'AAPL', ' MSFT ' ", limit=1, client=fake_client)
+
+    assert set(data.keys()) == {"AAPL", "MSFT"}
+    assert fake_client.latest_request is not None
+    assert fake_client.latest_request["symbols"] == ["AAPL", "MSFT"]
+
+
 def test_fetch_bars_supports_multiple_symbols():
     fake_client = FakeRESTClient()
     data = fetch_bars(["AAPL", "MSFT"], limit=1, client=fake_client)
@@ -66,6 +75,13 @@ def test_fetch_bars_requires_non_empty_symbols():
 
     with pytest.raises(ValueError):
         fetch_bars([], client=fake_client)
+
+
+def test_fetch_bars_rejects_blank_string():
+    fake_client = FakeRESTClient()
+
+    with pytest.raises(ValueError):
+        fetch_bars("   ", client=fake_client)
 
 
 def test_serialize_bars_single_symbol_returns_list():

--- a/tests/test_alpaca_provider.py
+++ b/tests/test_alpaca_provider.py
@@ -1,13 +1,21 @@
 import json
 import subprocess
 import sys
+from typing import Any
 
-from src.data.providers.alpaca import fetch_bars
+import pytest
+
+from src.data.providers.alpaca import Bar, _serialize_bars, fetch_bars, main
 
 
 class FakeRESTClient:
+    def __init__(self) -> None:
+        self.latest_request: dict[str, Any] | None = None
+
     def get_bars(self, symbols, timeframe, limit=5):
-        class Bar:
+        self.latest_request = {"symbols": symbols, "timeframe": timeframe, "limit": limit}
+
+        class FakeBar:
             def __init__(self, i):
                 self._raw = {
                     "t": f"2025-01-0{i+1}",
@@ -18,7 +26,7 @@ class FakeRESTClient:
                     "v": 1000 + i,
                 }
 
-        return {symbol: [Bar(i) for i in range(limit)] for symbol in symbols}
+        return {symbol: [FakeBar(i) for i in range(limit)] for symbol in symbols}
 
 
 def test_fetch_bars_returns_data():
@@ -31,14 +39,62 @@ def test_fetch_bars_returns_data():
     assert hasattr(data["AAPL"][0], "t")
 
 
+def test_fetch_bars_accepts_string_symbol():
+    fake_client = FakeRESTClient()
+    data = fetch_bars("AAPL", limit=2, client=fake_client)
+
+    assert list(data.keys()) == ["AAPL"]
+    assert len(data["AAPL"]) == 2
+    assert fake_client.latest_request is not None
+    assert fake_client.latest_request["symbols"] == ["AAPL"]
+    assert fake_client.latest_request["limit"] == 2
+
+
+def test_fetch_bars_supports_multiple_symbols():
+    fake_client = FakeRESTClient()
+    data = fetch_bars(["AAPL", "MSFT"], limit=1, client=fake_client)
+
+    assert set(data.keys()) == {"AAPL", "MSFT"}
+    assert all(len(bars) == 1 for bars in data.values())
+    assert fake_client.latest_request is not None
+    assert fake_client.latest_request["symbols"] == ["AAPL", "MSFT"]
+    assert fake_client.latest_request["limit"] == 1
+
+
+def test_fetch_bars_requires_non_empty_symbols():
+    fake_client = FakeRESTClient()
+
+    with pytest.raises(ValueError):
+        fetch_bars([], client=fake_client)
+
+
+def test_serialize_bars_single_symbol_returns_list():
+    payload = {"AAPL": [Bar(t="2024-01-01", o=1, h=1, low=1, c=1, v=1)]}
+
+    serialized = json.loads(_serialize_bars(payload))
+
+    assert isinstance(serialized, list)
+    assert serialized[0]["o"] == 1
+
+
+def test_serialize_bars_multiple_symbols_returns_dict():
+    payload = {
+        "AAPL": [Bar(t="2024-01-01", o=1, h=1, low=1, c=1, v=1)],
+        "MSFT": [Bar(t="2024-01-01", o=2, h=2, low=2, c=2, v=2)],
+    }
+
+    serialized = json.loads(_serialize_bars(payload))
+
+    assert isinstance(serialized, dict)
+    assert set(serialized.keys()) == {"AAPL", "MSFT"}
+
+
 def test_cli_fetch():
     # This test requires Alpaca credentials to be set in the environment
     # It will be skipped if they are not present
     import os
 
     if not os.environ.get("ALPACA_KEY_ID") or not os.environ.get("ALPACA_SECRET_KEY"):
-        import pytest
-
         pytest.skip("Skipping CLI test because Alpaca credentials are not set")
 
     result = subprocess.run(
@@ -56,3 +112,44 @@ def test_cli_fetch():
     assert "c" in data[0]
     assert "v" in data[0]
     assert "t" in data[0]
+
+
+def test_main_fetch_with_explicit_symbols(monkeypatch, capsys):
+    captured: dict[str, Any] = {}
+
+    def fake_fetch(symbols, limit, settings):
+        captured["symbols"] = symbols
+        return {"AAPL": [Bar(t="2024-01-01", o=1, h=1, low=1, c=1, v=1)]}
+
+    monkeypatch.setattr("src.data.providers.alpaca.fetch_bars", fake_fetch)
+    exit_code = main(["fetch", "AAPL", "--limit", "1"])
+
+    assert exit_code == 0
+    out = json.loads(capsys.readouterr().out)
+    assert isinstance(out, list)
+    assert captured["symbols"] == ["AAPL"]
+
+
+def test_main_fetch_without_symbols_uses_settings(monkeypatch, capsys):
+    captured: dict[str, Any] = {}
+
+    class FakeSettings:
+        def __init__(self):
+            self.symbol_list = ["IBM", "ORCL"]
+
+    def fake_fetch(symbols, limit, settings):
+        captured["symbols"] = symbols
+        return {
+            "IBM": [Bar(t="2024-01-01", o=1, h=1, low=1, c=1, v=1)],
+            "ORCL": [Bar(t="2024-01-01", o=2, h=2, low=2, c=2, v=2)],
+        }
+
+    monkeypatch.setattr("src.data.providers.alpaca.Settings", FakeSettings)
+    monkeypatch.setattr("src.data.providers.alpaca.fetch_bars", fake_fetch)
+
+    exit_code = main(["fetch", "--limit", "1"])
+
+    assert exit_code == 0
+    out = json.loads(capsys.readouterr().out)
+    assert isinstance(out, dict)
+    assert captured["symbols"] == ["IBM", "ORCL"]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,25 @@
+from src.config import Settings
+
+
+def test_symbol_list_uses_class_defaults():
+    settings = Settings()
+
+    assert settings.symbol_list == ["AAPL", "MSFT", "SPY"]
+
+
+def test_symbol_list_parses_comma_separated_string():
+    settings = Settings(symbols="'AAPL', ' MSFT ', 'SPY'")
+
+    assert settings.symbol_list == ["AAPL", "MSFT", "SPY"]
+
+
+def test_symbol_list_filters_blank_entries_from_sequence():
+    settings = Settings(symbols=[" AAPL ", " ", "MSFT"])
+
+    assert settings.symbol_list == ["AAPL", "MSFT"]
+
+
+def test_symbol_list_returns_empty_list_for_blank_string():
+    settings = Settings(symbols="   ")
+
+    assert settings.symbol_list == []


### PR DESCRIPTION
## Summary
- add a Settings.symbol_list helper and teach the BaseSettings shim to ignore properties
- extend the Alpaca provider tests to cover string symbols, validation, serialization, and CLI flows

## Testing
- PYTHONPATH=. poetry run pytest
- pre-commit run --files src/config.py src/pydantic_settings/__init__.py tests/test_alpaca_provider.py *(fails: detect-secrets baseline in repo is invalid)*

------
https://chatgpt.com/codex/tasks/task_e_68ead891382083328ad9b7bd07610319